### PR TITLE
fix: [diag] Correctly set DB session errorCode

### DIFF
--- a/app/Model/Server.php
+++ b/app/Model/Server.php
@@ -3391,6 +3391,7 @@ class Server extends AppModel
                 $sqlResult = $this->query($sql);
                 if (isset($sqlResult[0][0])) {
                     $sessionCount = $sqlResult[0][0]['session_count'];
+                    $errorCode = 0;
                 } else {
                     $errorCode = 9;
                 }


### PR DESCRIPTION
With the recent changes to session diagnostics in PR #8393, when using the database session handler, the test reports "Test failed" when nothing is wrong.  This is because errorCode is set to 9 ("Test failed") at the start of the function, but then never changed after success.  This fix sets the errorCode to 0 ("OK") after sessionCount is successfully retrieved from the DB.